### PR TITLE
URLを扱うのにcpp-netlibではなくてLUrlParserを使うようにした

### DIFF
--- a/core/License_LUrlParser.txt
+++ b/core/License_LUrlParser.txt
@@ -1,0 +1,23 @@
+https://github.com/corporateshark/LUrlParser
+
+The MIT License (MIT)
+
+Copyright (C) 2015 Sergey Kosarevsky (sk@linderdaum.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/core/common/LUrlParser.cpp
+++ b/core/common/LUrlParser.cpp
@@ -1,0 +1,263 @@
+/*
+ * Lightweight URL & URI parser (RFC 1738, RFC 3986)
+ * https://github.com/corporateshark/LUrlParser
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (C) 2015 Sergey Kosarevsky (sk@linderdaum.com)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "LUrlParser.h"
+
+#include <algorithm>
+#include <cstring>
+#include <stdlib.h>
+
+// check if the scheme name is valid
+static bool IsSchemeValid( const std::string& SchemeName )
+{
+	for ( auto c : SchemeName  )
+	{
+		if ( !isalpha( c ) && c != '+' && c != '-' && c != '.' ) return false;
+	}
+
+	return true;
+}
+
+bool LUrlParser::clParseURL::GetPort( int* OutPort ) const
+{
+	if ( !IsValid() ) { return false; }
+
+	int Port = atoi( m_Port.c_str() );
+
+	if ( Port <= 0 || Port > 65535 ) { return false; }
+
+	if ( OutPort ) { *OutPort = Port; }
+
+	return true;
+}
+
+// based on RFC 1738 and RFC 3986
+LUrlParser::clParseURL LUrlParser::clParseURL::ParseURL( const std::string& URL )
+{
+	LUrlParser::clParseURL Result;
+
+	const char* CurrentString = URL.c_str();
+
+	/*
+	 *	<scheme>:<scheme-specific-part>
+	 *	<scheme> := [a-z\+\-\.]+
+	 *	For resiliency, programs interpreting URLs should treat upper case letters as equivalent to lower case in scheme names
+	 */
+
+	// try to read scheme
+	{
+		const char* LocalString = strchr( CurrentString, ':' );
+
+		if ( !LocalString )
+		{
+			return clParseURL( LUrlParserError_NoUrlCharacter );
+		}
+
+		// save the scheme name
+		Result.m_Scheme = std::string( CurrentString, LocalString - CurrentString );
+
+		if ( !IsSchemeValid( Result.m_Scheme ) )
+		{
+			return clParseURL( LUrlParserError_InvalidSchemeName );
+		}
+
+		// scheme should be lowercase
+		std::transform( Result.m_Scheme.begin(), Result.m_Scheme.end(), Result.m_Scheme.begin(), ::tolower );
+
+		// skip ':'
+		CurrentString = LocalString+1;
+	}
+
+	/*
+	 *	//<user>:<password>@<host>:<port>/<url-path>
+	 *	any ":", "@" and "/" must be normalized
+	 */
+
+	// skip "//"
+	if ( *CurrentString++ != '/' ) return clParseURL( LUrlParserError_NoDoubleSlash );
+	if ( *CurrentString++ != '/' ) return clParseURL( LUrlParserError_NoDoubleSlash );
+
+	// check if the user name and password are specified
+	bool bHasUserName = false;
+
+	const char* LocalString = CurrentString;
+
+	while ( *LocalString )
+	{
+		if ( *LocalString == '@' )
+		{
+			// user name and password are specified
+			bHasUserName = true;
+			break;
+		}
+		else if ( *LocalString == '/' )
+		{
+			// end of <host>:<port> specification
+			bHasUserName = false;
+			break;
+		}
+
+		LocalString++;
+	}
+
+	// user name and password
+	LocalString = CurrentString;
+
+	if ( bHasUserName )
+	{
+		// read user name
+		while ( *LocalString && *LocalString != ':' && *LocalString != '@' ) LocalString++;
+
+		Result.m_UserName = std::string( CurrentString, LocalString - CurrentString );
+
+		// proceed with the current pointer
+		CurrentString = LocalString;
+
+		if ( *CurrentString == ':' )
+		{
+			// skip ':'
+			CurrentString++;
+
+			// read password
+			LocalString = CurrentString;
+
+			while ( *LocalString && *LocalString != '@' ) LocalString++;
+
+			Result.m_Password = std::string( CurrentString, LocalString - CurrentString );
+
+			CurrentString = LocalString;
+		}
+
+		// skip '@'
+		if ( *CurrentString != '@' )
+		{
+			return clParseURL( LUrlParserError_NoAtSign );
+		}
+
+		CurrentString++;
+	}
+
+	bool bHasBracket = ( *CurrentString == '[' );
+
+	// go ahead, read the host name
+	LocalString = CurrentString;
+
+	while ( *LocalString )
+	{
+		if ( bHasBracket && *LocalString == ']' )
+		{
+			// end of IPv6 address
+			LocalString++;
+			break;
+		}
+		else if ( !bHasBracket && ( *LocalString == ':' || *LocalString == '/' ) )
+		{
+			// port number is specified
+			break;
+		}
+
+		LocalString++;
+	}
+
+	Result.m_Host = std::string( CurrentString, LocalString - CurrentString );
+
+	CurrentString = LocalString;
+
+	// is port number specified?
+	if ( *CurrentString == ':' )
+	{
+		CurrentString++;
+
+		// read port number
+		LocalString = CurrentString;
+
+		while ( *LocalString && *LocalString != '/' ) LocalString++;
+
+		Result.m_Port = std::string( CurrentString, LocalString - CurrentString );
+
+		CurrentString = LocalString;
+	}
+
+	// end of string
+	if ( !*CurrentString )
+	{
+		return clParseURL( LUrlParserError_UnexpectedEndOfLine );
+	}
+
+	// skip '/'
+	if ( *CurrentString != '/' )
+	{
+		return clParseURL( LUrlParserError_NoSlash );
+	}
+
+	CurrentString++;
+
+	// parse the path
+	LocalString = CurrentString;
+
+	while ( *LocalString && *LocalString != '#' && *LocalString != '?' ) LocalString++;
+
+	Result.m_Path = std::string( CurrentString, LocalString - CurrentString );
+
+	CurrentString = LocalString;
+
+	// check for query
+	if ( *CurrentString == '?' )
+	{
+		// skip '?'
+		CurrentString++;
+
+		// read query
+		LocalString = CurrentString;
+
+		while ( *LocalString && *LocalString != '#' ) LocalString++;
+
+		Result.m_Query = std::string( CurrentString, LocalString - CurrentString );
+
+		CurrentString = LocalString;
+	}
+
+	// check for fragment
+	if ( *CurrentString == '#' )
+	{
+		// skip '#'
+		CurrentString++;
+
+		// read fragment
+		LocalString = CurrentString;
+
+		while ( *LocalString ) LocalString++;
+
+		Result.m_Fragment = std::string( CurrentString, LocalString - CurrentString );
+
+		CurrentString = LocalString;
+	}
+
+	Result.m_ErrorCode = LUrlParserError_Ok;
+
+	return Result;
+}

--- a/core/common/LUrlParser.cpp
+++ b/core/common/LUrlParser.cpp
@@ -202,19 +202,11 @@ LUrlParser::clParseURL LUrlParser::clParseURL::ParseURL( const std::string& URL 
 		CurrentString = LocalString;
 	}
 
-	// end of string
-	if ( !*CurrentString )
-	{
-		return clParseURL( LUrlParserError_UnexpectedEndOfLine );
-	}
-
 	// skip '/'
-	if ( *CurrentString != '/' )
+	if ( *CurrentString == '/' )
 	{
-		return clParseURL( LUrlParserError_NoSlash );
+		CurrentString++;
 	}
-
-	CurrentString++;
 
 	// parse the path
 	LocalString = CurrentString;

--- a/core/common/LUrlParser.h
+++ b/core/common/LUrlParser.h
@@ -1,0 +1,78 @@
+/*
+ * Lightweight URL & URI parser (RFC 1738, RFC 3986)
+ * https://github.com/corporateshark/LUrlParser
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (C) 2015 Sergey Kosarevsky (sk@linderdaum.com)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace LUrlParser
+{
+	enum LUrlParserError
+	{
+		LUrlParserError_Ok = 0,
+		LUrlParserError_Uninitialized = 1,
+		LUrlParserError_NoUrlCharacter = 2,
+		LUrlParserError_InvalidSchemeName = 3,
+		LUrlParserError_NoDoubleSlash = 4,
+		LUrlParserError_NoAtSign = 5,
+		LUrlParserError_UnexpectedEndOfLine = 6,
+		LUrlParserError_NoSlash = 7,
+	};
+
+	class clParseURL
+	{
+	public:
+		LUrlParserError m_ErrorCode;
+		std::string m_Scheme;
+		std::string m_Host;
+		std::string m_Port;
+		std::string m_Path;
+		std::string m_Query;
+		std::string m_Fragment;
+		std::string m_UserName;
+		std::string m_Password;
+
+		clParseURL()
+			: m_ErrorCode( LUrlParserError_Uninitialized )
+		{}
+
+		/// return 'true' if the parsing was successful
+		bool IsValid() const { return m_ErrorCode == LUrlParserError_Ok; }
+
+		/// helper to convert the port number to int, return 'true' if the port is valid (within the 0..65535 range)
+		bool GetPort( int* OutPort ) const;
+
+		/// parse the URL
+		static clParseURL ParseURL( const std::string& URL );
+
+	private:
+		explicit clParseURL( LUrlParserError ErrorCode )
+			: m_ErrorCode( ErrorCode )
+		{}
+	};
+
+} // namespace LUrlParser

--- a/core/common/uri.cpp
+++ b/core/common/uri.cpp
@@ -1,0 +1,62 @@
+#include "uri.h"
+
+#include <boost/network/protocol/http/client.hpp>
+
+using namespace boost::network::uri;
+
+URI::URI(const std::string& uriString)
+    : m_uri(new uri(uriString))
+{
+}
+
+URI::~URI()
+{
+    delete m_uri;
+}
+
+bool        URI::isValid()
+{
+    return m_uri->is_valid();
+}
+
+std::string URI::scheme()
+{
+    return m_uri->scheme();
+}
+
+std::string URI::host()
+{
+    return m_uri->host();
+}
+
+int         URI::port()
+{
+    if (m_uri->port() == "")
+        return defaultPort(scheme());
+    else {
+        int p;
+        sscanf(m_uri->port().c_str(), "%d", &p);
+        return p;
+    }
+}
+
+std::string URI::path()
+{
+    if (m_uri->path() == "")
+        return "/";
+    else
+        return m_uri->path();
+}
+
+std::string URI::fragment()
+{
+    return m_uri->fragment();
+}
+
+int URI::defaultPort(const std::string& scheme)
+{
+    if (scheme == "http")
+        return 80;
+    else
+        return 0;
+}

--- a/core/common/uri.cpp
+++ b/core/common/uri.cpp
@@ -1,12 +1,13 @@
 #include "uri.h"
 
-#include <boost/network/protocol/http/client.hpp>
+#include "LUrlParser.h"
 
-using namespace boost::network::uri;
+using namespace LUrlParser;
 
 URI::URI(const std::string& uriString)
-    : m_uri(new uri(uriString))
+    : m_uri(new clParseURL())
 {
+    *m_uri = clParseURL::ParseURL(uriString);
 }
 
 URI::~URI()
@@ -16,51 +17,45 @@ URI::~URI()
 
 bool        URI::isValid()
 {
-    return m_uri->is_valid();
+    return m_uri->IsValid();
 }
 
 std::string URI::scheme()
 {
-    return m_uri->scheme();
+    return m_uri->m_Scheme;
 }
 
 std::string URI::user_info()
 {
-    return m_uri->user_info();
+    return m_uri->m_UserName + ":" + m_uri->m_Password;
 }
 
 std::string URI::host()
 {
-    return m_uri->host();
+    return m_uri->m_Host;
 }
 
 int         URI::port()
 {
-    if (m_uri->port() == "")
-        return defaultPort(scheme());
-    else {
-        int p;
-        sscanf(m_uri->port().c_str(), "%d", &p);
+    int p;
+    if (m_uri->GetPort(&p)) {
         return p;
-    }
+    } else return -1;
 }
 
 std::string URI::path()
 {
-    if (m_uri->path() == "")
-        return "/";
-    else
-        return m_uri->path();
+    return m_uri->m_Path;
 }
 
 std::string URI::query()
 {
-    return m_uri->query();
+    return m_uri->m_Query;
 }
 
 std::string URI::fragment()
 {
-    return m_uri->fragment();
+    return m_uri->m_Fragment;
 }
 
 int URI::defaultPort(const std::string& scheme)

--- a/core/common/uri.cpp
+++ b/core/common/uri.cpp
@@ -24,6 +24,11 @@ std::string URI::scheme()
     return m_uri->scheme();
 }
 
+std::string URI::user_info()
+{
+    return m_uri->user_info();
+}
+
 std::string URI::host()
 {
     return m_uri->host();
@@ -46,6 +51,11 @@ std::string URI::path()
         return "/";
     else
         return m_uri->path();
+}
+
+std::string URI::query()
+{
+    return m_uri->query();
 }
 
 std::string URI::fragment()

--- a/core/common/uri.cpp
+++ b/core/common/uri.cpp
@@ -40,12 +40,14 @@ int         URI::port()
     int p;
     if (m_uri->GetPort(&p)) {
         return p;
-    } else return -1;
+    } else {
+        return defaultPort(scheme());
+    }
 }
 
 std::string URI::path()
 {
-    return m_uri->m_Path;
+    return "/" + m_uri->m_Path;
 }
 
 std::string URI::query()

--- a/core/common/uri.h
+++ b/core/common/uri.h
@@ -14,9 +14,11 @@ public:
 
     bool        isValid();
     std::string scheme();
+    std::string user_info();
     std::string host();
     int         port();
     std::string path();
+    std::string query();
     std::string fragment();
 
     boost::network::uri::uri* m_uri;

--- a/core/common/uri.h
+++ b/core/common/uri.h
@@ -1,0 +1,27 @@
+#ifndef _URI_H
+#define _URI_H
+
+#include <string>
+
+// forward-declare boost::network::uri::uri
+namespace boost { namespace network { namespace uri { class uri; } } }
+
+class URI
+{
+public:
+    URI(const std::string& uriString);
+    ~URI();
+
+    bool        isValid();
+    std::string scheme();
+    std::string host();
+    int         port();
+    std::string path();
+    std::string fragment();
+
+    boost::network::uri::uri* m_uri;
+
+    static int defaultPort(const std::string&);
+};
+
+#endif

--- a/core/common/uri.h
+++ b/core/common/uri.h
@@ -3,8 +3,8 @@
 
 #include <string>
 
-// forward-declare boost::network::uri::uri
-namespace boost { namespace network { namespace uri { class uri; } } }
+// forward-declare LUrlParser::clParseURL
+namespace LUrlParser { class clParseURL; }
 
 class URI
 {
@@ -21,7 +21,7 @@ public:
     std::string query();
     std::string fragment();
 
-    boost::network::uri::uri* m_uri;
+    LUrlParser::clParseURL* m_uri;
 
     static int defaultPort(const std::string&);
 };

--- a/tests/uri_unittest.cpp
+++ b/tests/uri_unittest.cpp
@@ -62,7 +62,7 @@ TEST_F(URIFixture, invalidURI)
     URI u("hoge");
 
     ASSERT_FALSE(u.isValid());
-    EXPECT_STREQ("hoge", u.scheme().c_str()); // おかしいけど、こうなる。
+    EXPECT_STREQ("", u.scheme().c_str());
 }
 
 TEST_F(URIFixture, emptyURI)
@@ -73,11 +73,18 @@ TEST_F(URIFixture, emptyURI)
     ASSERT_FALSE(u.isValid());
 }
 
+// TEST_F(URIFixture, mailtoScheme)
+// {
+//     URI u("mailto:webmaster@example.com");
+//     ASSERT_TRUE(u.isValid());
+//     ASSERT_STREQ("mailto", u.scheme().c_str());
+//     ASSERT_STREQ("webmaster@example.com", u.path().c_str());
+//     ASSERT_STREQ("", u.host().c_str());
+// }
+
+// mailtoスキームには対応しない。
 TEST_F(URIFixture, mailtoScheme)
 {
     URI u("mailto:webmaster@example.com");
-    ASSERT_TRUE(u.isValid());
-    ASSERT_STREQ("mailto", u.scheme().c_str());
-    ASSERT_STREQ("webmaster@example.com", u.path().c_str());
-    ASSERT_STREQ("", u.host().c_str());
+    ASSERT_FALSE(u.isValid());
 }

--- a/tests/uri_unittest.cpp
+++ b/tests/uri_unittest.cpp
@@ -22,6 +22,7 @@ public:
     }
 };
 
+#include "LUrlParser.h"
 TEST_F(URIFixture, httpScheme)
 {
     URI u("http://www.example.com");

--- a/tests/uri_unittest.cpp
+++ b/tests/uri_unittest.cpp
@@ -1,13 +1,11 @@
-// boost::network::uri::uri クラスのテスト。
+// URI クラスのテスト。
 
-#include <boost/network/protocol/http/client.hpp>
 #include <gtest/gtest.h>
+#include "uri.h"
 
-using namespace boost::network::uri;
-
-class uriFixture : public ::testing::Test {
+class URIFixture : public ::testing::Test {
 public:
-    uriFixture()
+    URIFixture()
     {
     }
 
@@ -19,65 +17,65 @@ public:
     {
     }
 
-    ~uriFixture()
+    ~URIFixture()
     {
     }
 };
 
-TEST_F(uriFixture, httpScheme)
+TEST_F(URIFixture, httpScheme)
 {
-    uri u("http://www.example.com");
+    URI u("http://www.example.com");
 
-    ASSERT_TRUE(u.is_valid());
+    ASSERT_TRUE(u.isValid());
     ASSERT_STREQ("http", u.scheme().c_str());
     ASSERT_STREQ("www.example.com", u.host().c_str());
-    ASSERT_STREQ("", u.port().c_str()); // 自動的に "80" にはならない。
-    ASSERT_STREQ("", u.path().c_str()); // パスが省略されている場合は "/" にはならない。
+    ASSERT_EQ(80, u.port()); // ポート指定がない場合はスキームのデフォルトポート。
+    ASSERT_STREQ("/", u.path().c_str()); // パスが省略されている場合は "/" になる。
 }
 
-TEST_F(uriFixture, httpSchemeWithPortQueryAndFragment)
+TEST_F(URIFixture, httpSchemeWithPortQueryAndFragment)
 {
-    uri u("http://localhost:7144/html/en/index.html?name=%E4%BA%88%E5%AE%9A%E5%9C%B0#top");
+    URI u("http://localhost:7144/html/en/index.html?name=%E4%BA%88%E5%AE%9A%E5%9C%B0#top");
 
-    ASSERT_TRUE(u.is_valid());
+    ASSERT_TRUE(u.isValid());
     ASSERT_STREQ("http", u.scheme().c_str());
     ASSERT_STREQ("localhost", u.host().c_str());
-    ASSERT_STREQ("7144", u.port().c_str());
+    ASSERT_EQ(7144, u.port());
     ASSERT_STREQ("/html/en/index.html", u.path().c_str());
     ASSERT_STREQ("name=%E4%BA%88%E5%AE%9A%E5%9C%B0", u.query().c_str()); // 自動的に unescape はされない。
     ASSERT_STREQ("top", u.fragment().c_str());
 }
 
-TEST_F(uriFixture, ftpScheme)
+TEST_F(URIFixture, ftpScheme)
 {
-    uri u("ftp://user:pass@localhost/pub/file.bin");
-    ASSERT_TRUE(u.is_valid());
+    URI u("ftp://user:pass@localhost/pub/file.bin");
+    ASSERT_TRUE(u.isValid());
     ASSERT_STREQ("ftp", u.scheme().c_str());
     ASSERT_STREQ("user:pass", u.user_info().c_str());
     ASSERT_STREQ("localhost", u.host().c_str());
     ASSERT_STREQ("/pub/file.bin", u.path().c_str());
 }
 
-TEST_F(uriFixture, invalidUri)
+TEST_F(URIFixture, invalidURI)
 {
-    uri u("hoge");
+    URI u("hoge");
 
-    ASSERT_FALSE(u.is_valid());
+    ASSERT_FALSE(u.isValid());
     EXPECT_STREQ("hoge", u.scheme().c_str()); // おかしいけど、こうなる。
 }
 
-TEST_F(uriFixture, emptyUri)
+TEST_F(URIFixture, emptyURI)
 {
-    ASSERT_NO_THROW(uri(""));
+    ASSERT_NO_THROW(URI(""));
 
-    uri u("");
-    ASSERT_FALSE(u.is_valid());
+    URI u("");
+    ASSERT_FALSE(u.isValid());
 }
 
-TEST_F(uriFixture, mailtoScheme)
+TEST_F(URIFixture, mailtoScheme)
 {
-    uri u("mailto:webmaster@example.com");
-    ASSERT_TRUE(u.is_valid());
+    URI u("mailto:webmaster@example.com");
+    ASSERT_TRUE(u.isValid());
     ASSERT_STREQ("mailto", u.scheme().c_str());
     ASSERT_STREQ("webmaster@example.com", u.path().c_str());
     ASSERT_STREQ("", u.host().c_str());

--- a/ui/linux/makefile
+++ b/ui/linux/makefile
@@ -44,7 +44,8 @@ CORESOURCE = \
 	$(CORE)/common/jis.cpp \
 	$(CORE)/common/flv.cpp \
 	$(CORE)/common/jrpc.cpp \
-	$(CORE)/common/chandir.cpp
+	$(CORE)/common/chandir.cpp \
+	$(CORE)/common/uri.cpp
 
 COREOBJ = $(notdir $(CORESOURCE:.cpp=.o))
 SYSOBJ = $(notdir $(SYSSOURCE:.cpp=.o))

--- a/ui/linux/makefile
+++ b/ui/linux/makefile
@@ -1,6 +1,6 @@
 CPPFLAGS = -g -Wno-multichar -Wno-unused-variable -std=c++11 -D_UNIX -D_REENTRANT $(INCLUDES)
 LDFLAGS = -pthread
-LIBS = -lboost_system -lcppnetlib-uri
+LIBS = 
 
 TAR = peercast-linux.tar
 CC = gcc
@@ -45,7 +45,9 @@ CORESOURCE = \
 	$(CORE)/common/flv.cpp \
 	$(CORE)/common/jrpc.cpp \
 	$(CORE)/common/chandir.cpp \
-	$(CORE)/common/uri.cpp
+	$(CORE)/common/uri.cpp \
+	$(CORE)/common/LUrlParser.cpp
+
 
 COREOBJ = $(notdir $(CORESOURCE:.cpp=.o))
 SYSOBJ = $(notdir $(SYSSOURCE:.cpp=.o))


### PR DESCRIPTION
パスが省略されたURL(http://example.com など)を合法として扱うように LUrlParser を修正。
ラッパークラスとして class URI を作成した。