### PR TITLE
make完了時に出力されるtarファイルの名前にunameを利用するように

### DIFF
--- a/ui/linux/makefile
+++ b/ui/linux/makefile
@@ -2,7 +2,10 @@ CPPFLAGS = -g -Wno-multichar -Wno-unused-variable -std=c++11 -D_UNIX -D_REENTRAN
 LDFLAGS = -pthread
 LIBS = 
 
-TAR = peercast-yt-linux-amd64.tar.gz
+OS = $(shell uname -s | tr A-Z a-z)
+ARCH = $(shell uname -p | tr A-Z a-z)
+
+TAR = peercast-yt-$(OS)-$(ARCH).tar.gz
 AR = ar
 
 INCLUDES = -I../../core -I../../core/common


### PR DESCRIPTION
ファイル名が固定されていたのでaarch64環境のlinuxでも``linux-amd64``となっていた

#### 修正前

- peercast-yt-linux-amd64.tar.gz

#### 修正後

- peercast-yt-linux-x86_64.tar.gz
- peercast-yt-linux-aarch64.tar.gz