### PR TITLE
2.8.11-0ubuntu0.16.04.1でエラーがでてWMV再生できなかった問題を修正 (fix #40)

### DIFF
--- a/ui/linux/cgi-bin/flv.cgi
+++ b/ui/linux/cgi-bin/flv.cgi
@@ -24,7 +24,8 @@ def main
          "-v", "-8", # quiet
          "-y",       # confirm overwriting
          "-i", "mmsh://#{server_name}:#{server_port}/stream/#{id}.wmv",
-         "-acodec", "aac",
+         "-strict", "-2",
+	 "-acodec", "aac",
          "-vcodec", "libx264",
          "-x264-params", "bitrate=#{r}:vbv-maxrate=#{r}:vbv-bufsize=#{2*r}",
          "-preset", "ultrafast",


### PR DESCRIPTION
Ubuntu 16.04 + ARM64環境での確認しか取っていないので他の環境ではエラーが出る可能性があります.

他ディストリで確認できていません ><