### PR TITLE
生きているスレッドを数える機能を削除。

### DIFF
--- a/core/common/channel.cpp
+++ b/core/common/channel.cpp
@@ -117,8 +117,6 @@ void Channel::endThread()
     reset();
 
     chanMgr->deleteChannel(this);
-
-    sys->endThread(&thread);
 }
 
 // -----------------------------------------------------------------------------

--- a/core/common/servent.cpp
+++ b/core/common/servent.cpp
@@ -1393,7 +1393,6 @@ int Servent::givProc(ThreadInfo *thread)
     }
 
     sv->kill();
-    sys->endThread(thread);
     return 0;
 }
 
@@ -1963,7 +1962,6 @@ int Servent::outgoingProc(ThreadInfo *thread)
     }
 
     sv->kill();
-    sys->endThread(thread);
     LOG_DEBUG("COUT ended");
     return 0;
 }
@@ -2002,7 +2000,6 @@ int Servent::incomingProc(ThreadInfo *thread)
     }
 
     sv->kill();
-    sys->endThread(thread);
     return 0;
 }
 
@@ -2553,7 +2550,6 @@ int Servent::serverProc(ThreadInfo *thread)
     LOG_DEBUG("Server stopped");
 
     sv->kill();
-    sys->endThread(thread);
     return 0;
 }
 

--- a/core/common/servmgr.cpp
+++ b/core/common/servmgr.cpp
@@ -1927,7 +1927,6 @@ int ServMgr::idleProc(ThreadInfo *thread)
         sys->sleep(500);
     }
 
-    sys->endThread(thread);
     return 0;
 }
 
@@ -2003,7 +2002,6 @@ int ServMgr::serverProc(ThreadInfo *thread)
         sys->sleepIdle();
     }
 
-    sys->endThread(thread);
     return 0;
 }
 

--- a/core/common/sys.cpp
+++ b/core/common/sys.cpp
@@ -41,7 +41,6 @@ Sys::Sys()
 {
     idleSleepTime = 10;
     logBuf = new LogBuffer(1000, 100);
-    numThreads=0;
 }
 
 // ------------------------------------------

--- a/core/common/sys.h
+++ b/core/common/sys.h
@@ -78,7 +78,6 @@ public:
     virtual bool            hasGUI() = 0;
     virtual void            callLocalURL(const char *, int)=0;
     virtual void            executeFile(const char *) = 0;
-    virtual void            endThread(ThreadInfo *) {}
     virtual void            waitThread(ThreadInfo *, int timeout = 30000) {}
     virtual void            setThreadName(ThreadInfo *, const char* name) {}
 
@@ -101,7 +100,6 @@ public:
 
     unsigned int idleSleepTime;
     unsigned int rndSeed;
-    unsigned int numThreads;
 
     class LogBuffer *logBuf;
 };

--- a/core/unix/usys.cpp
+++ b/core/unix/usys.cpp
@@ -69,16 +69,6 @@ ClientSocket *USys::createSocket()
 }
 
 // ---------------------------------
-void USys::endThread(ThreadInfo *info)
-{
-    numThreads--;
-
-    LOG_DEBUG("End thread: %d", numThreads);
-
-    //pthread_exit(NULL);
-}
-
-// ---------------------------------
 void USys::waitThread(ThreadInfo *info, int timeout)
 {
 #ifdef _GNU_SOURCE
@@ -95,8 +85,6 @@ bool    USys::startThread(ThreadInfo *info)
 {
     info->active = true;
 
-    LOG_DEBUG("New thread: %d", numThreads);
-
     pthread_attr_t attr;
 
     pthread_attr_init(&attr);
@@ -108,12 +96,11 @@ bool    USys::startThread(ThreadInfo *info)
 
     if (r)
     {
-        LOG_ERROR("Error creating thread %d: %d", numThreads, r);
+        LOG_ERROR("Error creating thread: %d", r);
         return false;
     }else
     {
-        setThreadName(info, String::format("thread %d", numThreads).cstr());
-        numThreads++;
+        setThreadName(info, "new thread");
         return true;
     }
 }

--- a/core/unix/usys.h
+++ b/core/unix/usys.h
@@ -43,7 +43,6 @@ public:
     bool            hasGUI() override { return false; }
     void            callLocalURL(const char *, int) override;
     void            executeFile(const char *) override;
-    void            endThread(ThreadInfo *) override;
     void            waitThread(ThreadInfo *, int timeout = 30000) override;
     void            setThreadName(ThreadInfo *, const char* name) override;
 

--- a/core/win32/wsys.cpp
+++ b/core/win32/wsys.cpp
@@ -66,11 +66,6 @@ ClientSocket *WSys::createSocket()
 }
 
 // ---------------------------------
-void WSys::endThread(ThreadInfo *info)
-{
-}
-
-// ---------------------------------
 void WSys::waitThread(ThreadInfo *info, int timeout)
 {
     switch(WaitForSingleObject((HANDLE)info->handle, timeout))

--- a/core/win32/wsys.h
+++ b/core/win32/wsys.h
@@ -44,7 +44,6 @@ public:
     virtual bool            hasGUI() { return mainWindow!=NULL; }
     virtual void            callLocalURL(const char *str,int port);
     virtual void            executeFile(const char *);
-    virtual void            endThread(ThreadInfo *);
     virtual void            waitThread(ThreadInfo *, int timeout = 30000);
 
     HWND    mainWindow;

--- a/tests/mocksys.h
+++ b/tests/mocksys.h
@@ -67,10 +67,6 @@ public:
     {
     }
 
-    void endThread(ThreadInfo*) override
-    {
-    }
-
     void waitThread(ThreadInfo*, int timeout = 30000) override
     {
     }


### PR DESCRIPTION
Sys::numThreads, Sys::endThread を削除。カウンターが保護されていないので、数え間違う可能性があった。WSys では実装されていないし、必須の機能とも思えないので削除した。