### PR TITLE
Channelオブジェクトは常にshared_ptrを通して扱うようにした

### DIFF
--- a/core/common/chanmgr.h
+++ b/core/common/chanmgr.h
@@ -35,15 +35,15 @@ public:
     ChanMgr();
     ~ChanMgr();
 
-    Channel *deleteChannel(Channel *);
+    void deleteChannel(std::shared_ptr<Channel>);
 
-    Channel *createChannel(ChanInfo &, const char *);
-    Channel *findChannelByName(const char *);
-    Channel *findChannelByIndex(int);
-    Channel *findChannelByMount(const char *);
-    Channel *findChannelByID(const GnuID &);
-    Channel *findChannelByNameID(ChanInfo &);
-    Channel *findPushChannel(int);
+    std::shared_ptr<Channel> createChannel(ChanInfo &, const char *);
+    std::shared_ptr<Channel> findChannelByName(const char *);
+    std::shared_ptr<Channel> findChannelByIndex(int);
+    std::shared_ptr<Channel> findChannelByMount(const char *);
+    std::shared_ptr<Channel> findChannelByID(const GnuID &);
+    std::shared_ptr<Channel> findChannelByNameID(ChanInfo &);
+    std::shared_ptr<Channel> findPushChannel(int);
 
     void    broadcastTrackerSettings();
     void    setUpdateInterval(unsigned int v);
@@ -54,8 +54,8 @@ public:
 
     bool    writeVariable(Stream &, const String &) override;
 
-    int     findChannels(ChanInfo &, Channel **, int);
-    int     findChannelsByStatus(Channel **, int, Channel::STATUS);
+    int     findChannels(ChanInfo &, std::shared_ptr<Channel> *, int);
+    int     findChannelsByStatus(std::shared_ptr<Channel> *, int, Channel::STATUS);
 
     int     numIdleChannels();
     int     numChannels();
@@ -81,8 +81,8 @@ public:
 
     void        setBroadcastMsg(::String &);
 
-    Channel     *createRelay(ChanInfo &, bool);
-    Channel     *findAndRelay(ChanInfo &);
+    std::shared_ptr<Channel> createRelay(ChanInfo &, bool);
+    std::shared_ptr<Channel> findAndRelay(ChanInfo &);
     void        startSearch(ChanInfo &);
 
     void        playChannel(ChanInfo &);
@@ -96,7 +96,7 @@ public:
     std::string authSecret(const GnuID& id);
     std::string authToken(const GnuID& id);
 
-    Channel         *channel;
+    std::shared_ptr<Channel> channel;
     ChanHitList     *hitlist;
 
     GnuID           broadcastID;

--- a/core/common/channel.cpp
+++ b/core/common/channel.cpp
@@ -330,6 +330,7 @@ THREAD_PROC Channel::stream(ThreadInfo *thread)
     auto ch = thread->channel;
 
     assert(thread->channel != nullptr);
+    thread->channel = nullptr; // make sure to not leave the reference behind
 
     sys->setThreadName("CHANNEL");
 

--- a/core/common/channel.h
+++ b/core/common/channel.h
@@ -77,18 +77,18 @@ public:
 class RawStream : public ChannelStream
 {
 public:
-    void readHeader(Stream &, Channel *) override;
-    int  readPacket(Stream &, Channel *) override;
-    void readEnd(Stream &, Channel *) override;
+    void readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int  readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void readEnd(Stream &, std::shared_ptr<Channel>) override;
 };
 
 // ------------------------------------------
 class PeercastStream : public ChannelStream
 {
 public:
-    void readHeader(Stream &, Channel *) override;
-    int  readPacket(Stream &, Channel *) override;
-    void readEnd(Stream &, Channel *) override;
+    void readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int  readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void readEnd(Stream &, std::shared_ptr<Channel>) override;
 };
 
 // ------------------------------------------
@@ -97,7 +97,7 @@ class ChannelSource
 public:
     virtual ~ChannelSource() {}
 
-    virtual void stream(Channel *) = 0;
+    virtual void stream(std::shared_ptr<Channel>) = 0;
     virtual int getSourceRate() { return 0; }
     virtual int getSourceRateAvg() { return this->getSourceRate(); }
 };
@@ -108,16 +108,17 @@ class PeercastSource : public ChannelSource
 public:
 
     PeercastSource() : m_channel(NULL) {}
-    void    stream(Channel *) override;
+    void    stream(std::shared_ptr<Channel>) override;
     int     getSourceRate() override;
     int     getSourceRateAvg() override;
-    ChanHit pickFromHitList(Channel *ch, ChanHit &oldHit);
+    ChanHit pickFromHitList(std::shared_ptr<Channel> ch, ChanHit &oldHit);
 
-    Channel*        m_channel;
+    std::shared_ptr<Channel> m_channel;
 };
 
 // ----------------------------------
-class Channel : public VariableWriter
+class Channel : public VariableWriter,
+                public std::enable_shared_from_this<Channel>
 {
 public:
 
@@ -290,7 +291,7 @@ public:
 
     WEvent              syncEvent;
 
-    Channel             *next;
+    std::shared_ptr<Channel> next;
 };
 
 #include "chanmgr.h"

--- a/core/common/common.h
+++ b/core/common/common.h
@@ -21,6 +21,7 @@
 
 #include <stdio.h> // snprintf
 #include <string>
+#include <assert.h>
 
 #include "gnuid.h"
 #include "host.h"

--- a/core/common/cstream.cpp
+++ b/core/common/cstream.cpp
@@ -313,7 +313,7 @@ bool    ChanPacketBuffer::willSkip()
 }
 
 // ------------------------------------------
-bool ChannelStream::getStatus(Channel *ch, ChanPacket &pack)
+bool ChannelStream::getStatus(std::shared_ptr<Channel> ch, ChanPacket &pack)
 {
     unsigned int ctime = sys->getTime();
 
@@ -375,7 +375,7 @@ bool ChannelStream::getStatus(Channel *ch, ChanPacket &pack)
 }
 
 // ------------------------------------------
-void ChannelStream::updateStatus(Channel *ch)
+void ChannelStream::updateStatus(std::shared_ptr<Channel> ch)
 {
     ChanPacket pack;
     if (getStatus(ch, pack))
@@ -390,7 +390,7 @@ void ChannelStream::updateStatus(Channel *ch)
 }
 
 // -----------------------------------
-void ChannelStream::readRaw(Stream &in, Channel *ch)
+void ChannelStream::readRaw(Stream &in, std::shared_ptr<Channel> ch)
 {
     ChanPacket pack;
     const int readLen = 8192;

--- a/core/common/cstream.h
+++ b/core/common/cstream.h
@@ -169,17 +169,17 @@ public:
 
     virtual ~ChannelStream() {}
 
-    void updateStatus(Channel *);
-    bool getStatus(Channel *, ChanPacket &);
+    void updateStatus(std::shared_ptr<Channel>);
+    bool getStatus(std::shared_ptr<Channel>, ChanPacket &);
 
     virtual void kill() {}
     virtual bool sendPacket(ChanPacket &, GnuID &) { return false; }
     virtual void flush(Stream &) {}
-    virtual void readHeader(Stream &, Channel *) = 0;
-    virtual int  readPacket(Stream &, Channel *) = 0;
-    virtual void readEnd(Stream &, Channel *) = 0;
+    virtual void readHeader(Stream &, std::shared_ptr<Channel>) = 0;
+    virtual int  readPacket(Stream &, std::shared_ptr<Channel>) = 0;
+    virtual void readEnd(Stream &, std::shared_ptr<Channel>) = 0;
 
-    void    readRaw(Stream &, Channel *);
+    void    readRaw(Stream &, std::shared_ptr<Channel>);
 
     int             numRelays;
     int             numListeners;

--- a/core/common/flv.cpp
+++ b/core/common/flv.cpp
@@ -29,12 +29,12 @@ static String timestampToString(uint32_t timestamp)
 }
 
 // ------------------------------------------
-void FLVStream::readEnd(Stream &, Channel *)
+void FLVStream::readEnd(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-void FLVStream::readHeader(Stream &in, Channel *ch)
+void FLVStream::readHeader(Stream &in, std::shared_ptr<Channel> ch)
 {
     metaBitrate = 0;
     fileHeader.read(in);
@@ -42,7 +42,7 @@ void FLVStream::readHeader(Stream &in, Channel *ch)
 }
 
 // ------------------------------------------
-int FLVStream::readPacket(Stream &in, Channel *ch)
+int FLVStream::readPacket(Stream &in, std::shared_ptr<Channel> ch)
 {
     bool headerUpdate = false;
 
@@ -152,7 +152,7 @@ int FLVStream::readPacket(Stream &in, Channel *ch)
     return 0;
 }
 
-bool FLVTagBuffer::put(FLVTag& tag, Channel* ch)
+bool FLVTagBuffer::put(FLVTag& tag, std::shared_ptr<Channel> ch)
 {
     if (tag.isKeyFrame())
     {
@@ -205,7 +205,7 @@ void FLVTagBuffer::rateLimit(uint32_t timestamp)
     }
 }
 
-void FLVTagBuffer::sendImmediately(FLVTag& tag, Channel* ch)
+void FLVTagBuffer::sendImmediately(FLVTag& tag, std::shared_ptr<Channel> ch)
 {
     if (ch->readDelay)
         rateLimit(tag.getTimestamp());
@@ -244,7 +244,7 @@ void FLVTagBuffer::sendImmediately(FLVTag& tag, Channel* ch)
     }
 }
 
-void FLVTagBuffer::flush(Channel* ch)
+void FLVTagBuffer::flush(std::shared_ptr<Channel> ch)
 {
     if (m_mem.pos == 0)
         return;

--- a/core/common/flv.h
+++ b/core/common/flv.h
@@ -196,8 +196,8 @@ public:
     {
     }
 
-    bool put(FLVTag& tag, Channel* ch);
-    void flush(Channel* ch);
+    bool put(FLVTag& tag, std::shared_ptr<Channel> ch);
+    void flush(std::shared_ptr<Channel> ch);
     void rateLimit(uint32_t timestamp);
 
     MemoryStream m_mem;
@@ -205,7 +205,7 @@ public:
     unsigned int startTime;
 
 private:
-    void sendImmediately(FLVTag& tag, Channel* ch);
+    void sendImmediately(FLVTag& tag, std::shared_ptr<Channel> ch);
 };
 
 // ----------------------------------------------
@@ -220,9 +220,9 @@ public:
     FLVStream() : metaBitrate(0)
     {
     }
-    void readHeader(Stream &, Channel *) override;
-    int  readPacket(Stream &, Channel *) override;
-    void readEnd(Stream &, Channel *) override;
+    void readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int  readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void readEnd(Stream &, std::shared_ptr<Channel>) override;
 
     FLVTagBuffer m_buffer;
 };

--- a/core/common/gnutella.cpp
+++ b/core/common/gnutella.cpp
@@ -125,7 +125,7 @@ void GnuPacket::initPush(ChanHit &ch, Host &sh)
 }
 
 // ---------------------------
-bool GnuPacket::initHit(Host &h, Channel *ch, GnuPacket *query, bool push, bool busy, bool stable, bool tracker, int maxttl)
+bool GnuPacket::initHit(Host &h, std::shared_ptr<Channel> ch, GnuPacket *query, bool push, bool busy, bool stable, bool tracker, int maxttl)
 {
     if (!ch)
         return false;
@@ -428,7 +428,7 @@ GnuStream::R_TYPE GnuStream::processPacket(GnuPacket &in, Servent *serv, GnuID &
                 MemoryStream xm(&data.buf[data.pos], data.len-data.pos);
                 xm.buf[xm.len] = 0;
 
-                Channel *hits[16];
+                std::shared_ptr<Channel> hits[16];
                 int numHits=0;
 
                 if (strncmp(xm.buf, "<?xml", 5)==0)

--- a/core/common/gnutella.h
+++ b/core/common/gnutella.h
@@ -125,7 +125,7 @@ public:
     void    initPing(int);
     void    initPong(Host &, bool, GnuPacket &);
     void    initFind(const char *, class XML *, int);
-    bool    initHit(Host &, Channel *, GnuPacket *, bool, bool, bool, bool, int);
+    bool    initHit(Host &, std::shared_ptr<Channel>, GnuPacket *, bool, bool, bool, bool, int);
     void    initPush(ChanHit &, Host &);
 
     void    makeChecksumID();

--- a/core/common/httppush.cpp
+++ b/core/common/httppush.cpp
@@ -5,7 +5,7 @@
 #include "dechunker.h"
 
 // ------------------------------------------------
-void HTTPPushSource::stream(Channel *ch)
+void HTTPPushSource::stream(std::shared_ptr<Channel> ch)
 {
     try
     {

--- a/core/common/httppush.h
+++ b/core/common/httppush.h
@@ -13,7 +13,7 @@ public:
     {
     }
 
-    void stream(Channel *) override;
+    void stream(std::shared_ptr<Channel>) override;
     int getSourceRate() override;
     int getSourceRateAvg() override;
 

--- a/core/common/icy.cpp
+++ b/core/common/icy.cpp
@@ -2,7 +2,7 @@
 #include "socket.h"
 
 // ------------------------------------------------
-void ICYSource::stream(Channel *ch)
+void ICYSource::stream(std::shared_ptr<Channel> ch)
 {
     ChannelStream *source=NULL;
     try

--- a/core/common/icy.h
+++ b/core/common/icy.h
@@ -25,7 +25,7 @@
 class ICYSource : public ChannelSource
 {
 public:
-    void stream(Channel *) override;
+    void stream(std::shared_ptr<Channel>) override;
 };
 
 #endif

--- a/core/common/jrpc.h
+++ b/core/common/jrpc.h
@@ -39,7 +39,7 @@ public:
     class HostGraph
     {
     public:
-        HostGraph(Channel *ch, ChanHitList *hitList)
+        HostGraph(std::shared_ptr<Channel> ch, ChanHitList *hitList)
         {
             if (ch == nullptr)
                 throw std::invalid_argument("ch");
@@ -288,7 +288,7 @@ public:
             info.id = chanMgr->broadcastID;
             info.id.encode(NULL, info.name, info.genre, info.bitrate);
 
-            Channel *c = chanMgr->createChannel(info, NULL); // info, mount
+            auto c = chanMgr->createChannel(info, NULL); // info, mount
             if (!c)
             {
                 throw application_error(0, "failed to create channel");
@@ -370,7 +370,7 @@ public:
         }
     }
 
-    json channelStatus(Channel *c)
+    json channelStatus(std::shared_ptr<Channel> c)
     {
         return {
             {"status", to_json(c->status)},
@@ -387,7 +387,7 @@ public:
         };
     }
 
-    json to_json(Channel *c)
+    json to_json(std::shared_ptr<Channel> c)
     {
         return {
             {"channelId", to_json(c->info.id)},
@@ -428,7 +428,7 @@ public:
 
         GnuID id = params[0].get<std::string>();
 
-        Channel *c = chanMgr->findChannelByID(id);
+        auto c = chanMgr->findChannelByID(id);
         if (!c)
             throw application_error(-1, "Channel not found");
 
@@ -497,7 +497,7 @@ public:
     {
         GnuID id(params[0].get<std::string>());
 
-        Channel *c = chanMgr->findChannelByID(id);
+        auto c = chanMgr->findChannelByID(id);
         if (!c)
             throw application_error(-1, "Channel not found");
 
@@ -514,7 +514,7 @@ public:
     {
         GnuID id(params[0].get<std::string>());
 
-        Channel *c = chanMgr->findChannelByID(id);
+        auto c = chanMgr->findChannelByID(id);
 
         if (!c)
             throw application_error(-1, "Channel not found");
@@ -527,7 +527,7 @@ public:
         json result = json::array();
 
         CriticalSection cs(chanMgr->lock);
-        for (Channel *c = chanMgr->channel; c != NULL; c = c->next)
+        for (auto c = chanMgr->channel; c != NULL; c = c->next)
         {
             result.push_back(to_json(c));
         }
@@ -620,7 +620,7 @@ public:
 
     // 配信中のチャンネルとルートサーバーとの接続状態。
     // 返り値: "Idle" | "Connecting" | "Connected" | "Error"
-    json::string_t announcingChannelStatus(Channel* c)
+    json::string_t announcingChannelStatus(std::shared_ptr<Channel> c)
     {
         return "Connected";
     }
@@ -630,7 +630,7 @@ public:
         json::array_t result;
 
         CriticalSection cs(chanMgr->lock);
-        for (Channel *c = chanMgr->channel; c != NULL; c = c->next)
+        for (auto c = chanMgr->channel; c != NULL; c = c->next)
         {
             if (!c->isBroadcasting())
                 continue;
@@ -777,7 +777,7 @@ public:
         json info             = args[1];
         json track            = args[2];
 
-        Channel *channel = chanMgr->findChannelByID(channelId);
+        auto channel = chanMgr->findChannelByID(channelId);
         if (!channel)
             throw application_error(0, "Channel not found");
 
@@ -792,7 +792,7 @@ public:
 
         GnuID id(channelId);
 
-        Channel *channel = chanMgr->findChannelByID(id);
+        auto channel = chanMgr->findChannelByID(id);
 
         if (channel)
             channel->thread.shutdown();
@@ -804,7 +804,7 @@ public:
     {
         GnuID id = args[0].get<std::string>();
 
-        Channel *channel = chanMgr->findChannelByID(id);
+        auto channel = chanMgr->findChannelByID(id);
         if (!channel)
             throw application_error(0, "Channel not found");
 
@@ -821,7 +821,7 @@ public:
     {
         GnuID id = args[0].get<std::string>();
 
-        Channel *channel = chanMgr->findChannelByID(id);
+        auto channel = chanMgr->findChannelByID(id);
         if (!channel)
             throw application_error(0, "Channel not found");
 

--- a/core/common/mkv.cpp
+++ b/core/common/mkv.cpp
@@ -9,7 +9,7 @@
 using namespace matroska;
 
 // data を type パケットとして送信する
-void MKVStream::sendPacket(ChanPacket::TYPE type, const byte_string& data, bool continuation, Channel* ch)
+void MKVStream::sendPacket(ChanPacket::TYPE type, const byte_string& data, bool continuation, std::shared_ptr<Channel> ch)
 {
     if (data.size() > ChanPacket::MAX_DATALEN)
         throw StreamException("MKV packet too big");
@@ -108,7 +108,7 @@ void MKVStream::rateLimit(uint64_t timecode)
 
 // 非継続パケットの頭出しができないクライアントのために、なるべく要素
 // をパケットの先頭にして送信する
-void MKVStream::sendCluster(const byte_string& cluster, Channel* ch)
+void MKVStream::sendCluster(const byte_string& cluster, std::shared_ptr<Channel> ch)
 {
     bool continuation;
 
@@ -253,7 +253,7 @@ void MKVStream::readInfo(const std::string& data)
     }
 }
 
-void MKVStream::readHeader(Stream &in, Channel *ch)
+void MKVStream::readHeader(Stream &in, std::shared_ptr<Channel> ch)
 {
     try{
         byte_string header;
@@ -323,7 +323,7 @@ void MKVStream::readHeader(Stream &in, Channel *ch)
 }
 
 // ビットレートの計測、更新
-void MKVStream::checkBitrate(Stream &in, Channel *ch)
+void MKVStream::checkBitrate(Stream &in, std::shared_ptr<Channel> ch)
 {
     ChanInfo info = ch->info;
     int newBitrate = in.stat.bytesInPerSecAvg() / 1000 * 8;
@@ -334,7 +334,7 @@ void MKVStream::checkBitrate(Stream &in, Channel *ch)
 }
 
 // Cluster 要素を読む
-int MKVStream::readPacket(Stream &in, Channel *ch)
+int MKVStream::readPacket(Stream &in, std::shared_ptr<Channel> ch)
 {
     try {
         checkBitrate(in, ch);
@@ -360,7 +360,7 @@ int MKVStream::readPacket(Stream &in, Channel *ch)
     }
 }
 
-void MKVStream::readEnd(Stream &, Channel *)
+void MKVStream::readEnd(Stream &, std::shared_ptr<Channel>)
 {
     // we will never reach the end
 }

--- a/core/common/mkv.h
+++ b/core/common/mkv.h
@@ -16,14 +16,14 @@ public:
         , m_startTime(0)
     {
     }
-    void readHeader(Stream &, Channel *) override;
-    int  readPacket(Stream &, Channel *) override;
-    void readEnd(Stream &, Channel *) override;
+    void readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int  readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void readEnd(Stream &, std::shared_ptr<Channel>) override;
 
-    void sendPacket(ChanPacket::TYPE, const matroska::byte_string& data, bool continuation, Channel*);
+    void sendPacket(ChanPacket::TYPE, const matroska::byte_string& data, bool continuation, std::shared_ptr<Channel>);
     bool hasKeyFrame(const matroska::byte_string& cluster);
-    void sendCluster(const matroska::byte_string& cluster, Channel* ch);
-    void checkBitrate(Stream &in, Channel *ch);
+    void sendCluster(const matroska::byte_string& cluster, std::shared_ptr<Channel> ch);
+    void checkBitrate(Stream &in, std::shared_ptr<Channel> ch);
     void readTracks(const std::string& data);
     void readInfo(const std::string& data);
 

--- a/core/common/mms.cpp
+++ b/core/common/mms.cpp
@@ -24,17 +24,17 @@
 ASFInfo parseASFHeader(Stream &in);
 
 // ------------------------------------------
-void MMSStream::readEnd(Stream &, Channel *)
+void MMSStream::readEnd(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-void MMSStream::readHeader(Stream &, Channel *)
+void MMSStream::readHeader(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-void MMSStream::processChunk(Stream &in, Channel *ch, ASFChunk& chunk)
+void MMSStream::processChunk(Stream &in, std::shared_ptr<Channel> ch, ASFChunk& chunk)
 {
     switch (chunk.type)
     {
@@ -91,7 +91,7 @@ void MMSStream::processChunk(Stream &in, Channel *ch, ASFChunk& chunk)
 }
 
 // ------------------------------------------
-int MMSStream::readPacket(Stream &in, Channel *ch)
+int MMSStream::readPacket(Stream &in, std::shared_ptr<Channel> ch)
 {
     ASFChunk chunk;
 

--- a/core/common/mms.h
+++ b/core/common/mms.h
@@ -26,11 +26,11 @@ class MMSStream : public ChannelStream
 {
 public:
 
-    void    readHeader(Stream &, Channel *) override;
-    int     readPacket(Stream &, Channel *) override;
-    void    readEnd(Stream &, Channel *) override;
+    void    readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int     readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void    readEnd(Stream &, std::shared_ptr<Channel>) override;
 
-    static void processChunk(Stream &in, Channel *ch, ASFChunk& chunk);
+    static void processChunk(Stream &in, std::shared_ptr<Channel> ch, ASFChunk& chunk);
 };
 
 #endif

--- a/core/common/mp3.cpp
+++ b/core/common/mp3.cpp
@@ -20,17 +20,17 @@
 #include "mp3.h"
 
 // ------------------------------------------
-void MP3Stream::readEnd(Stream &, Channel *)
+void MP3Stream::readEnd(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-void MP3Stream::readHeader(Stream &, Channel *)
+void MP3Stream::readHeader(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-int MP3Stream::readPacket(Stream &in, Channel *ch)
+int MP3Stream::readPacket(Stream &in, std::shared_ptr<Channel> ch)
 {
     ChanPacket pack;
 

--- a/core/common/mp3.h
+++ b/core/common/mp3.h
@@ -25,9 +25,9 @@
 class MP3Stream : public ChannelStream
 {
 public:
-    void    readHeader(Stream &, Channel *) override;
-    int     readPacket(Stream &, Channel *) override;
-    void    readEnd(Stream &, Channel *) override;
+    void    readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int     readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void    readEnd(Stream &, std::shared_ptr<Channel>) override;
 };
 
 #endif

--- a/core/common/nsv.cpp
+++ b/core/common/nsv.cpp
@@ -19,17 +19,17 @@
 #include "nsv.h"
 
 // ------------------------------------------
-void NSVStream::readEnd(Stream &, Channel *)
+void NSVStream::readEnd(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-void NSVStream::readHeader(Stream &, Channel *)
+void NSVStream::readHeader(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-int NSVStream::readPacket(Stream &in, Channel *ch)
+int NSVStream::readPacket(Stream &in, std::shared_ptr<Channel> ch)
 {
     ChanPacket pack;
 

--- a/core/common/nsv.h
+++ b/core/common/nsv.h
@@ -25,9 +25,9 @@
 class NSVStream : public ChannelStream
 {
 public:
-    void    readHeader(Stream &, Channel *) override;
-    int     readPacket(Stream &, Channel *) override;
-    void    readEnd(Stream &, Channel *) override;
+    void    readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int     readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void    readEnd(Stream &, std::shared_ptr<Channel>) override;
 };
 
 #endif

--- a/core/common/ogg.cpp
+++ b/core/common/ogg.cpp
@@ -22,18 +22,18 @@
 static int test=0;
 
 // ------------------------------------------
-void OGGStream::readHeader(Stream &, Channel *)
+void OGGStream::readHeader(Stream &, std::shared_ptr<Channel>)
 {
     test = 0;
 }
 
 // ------------------------------------------
-void OGGStream::readEnd(Stream &, Channel *)
+void OGGStream::readEnd(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-int OGGStream::readPacket(Stream &in, Channel *ch)
+int OGGStream::readPacket(Stream &in, std::shared_ptr<Channel> ch)
 {
     OggPage ogg;
     ChanPacket pack;
@@ -124,7 +124,7 @@ int OGGStream::readPacket(Stream &in, Channel *ch)
 }
 
 // -----------------------------------
-void OggSubStream::readHeader(Channel *ch, OggPage &ogg)
+void OggSubStream::readHeader(std::shared_ptr<Channel> ch, OggPage &ogg)
 {
     if ((pack.bodyLen + ogg.bodyLen) >= OggPacket::MAX_BODYLEN)
         throw StreamException("OGG packet too big");
@@ -147,7 +147,7 @@ void OggSubStream::readHeader(Channel *ch, OggPage &ogg)
 }
 
 // -----------------------------------
-void OggVorbisSubStream::procHeaders(Channel *ch)
+void OggVorbisSubStream::procHeaders(std::shared_ptr<Channel> ch)
 {
     unsigned int packPtr=0;
 
@@ -225,7 +225,7 @@ void OggTheoraSubStream::readInfo(Stream &in, ChanInfo &info)
 }
 
 // -----------------------------------
-void OggTheoraSubStream::procHeaders(Channel *ch)
+void OggTheoraSubStream::procHeaders(std::shared_ptr<Channel> ch)
 {
     unsigned int packPtr=0;
 

--- a/core/common/ogg.h
+++ b/core/common/ogg.h
@@ -75,9 +75,9 @@ public:
 
     bool    isActive() { return serialNo!=0; }
 
-    void    readHeader(Channel *, OggPage &);
+    void    readHeader(std::shared_ptr<Channel>, OggPage &);
 
-    virtual void procHeaders(Channel *) = 0;
+    virtual void procHeaders(std::shared_ptr<Channel>) = 0;
 
     int             bitrate;
 
@@ -94,7 +94,7 @@ public:
     :samplerate(0)
     {}
 
-    void    procHeaders(Channel *) override;
+    void    procHeaders(std::shared_ptr<Channel>) override;
 
     void    readIdent(Stream &, ChanInfo &);
     void    readSetup(Stream &);
@@ -111,7 +111,7 @@ class OggTheoraSubStream : public OggSubStream
 public:
     OggTheoraSubStream() : granposShift(0), frameTime(0) {}
 
-    void    procHeaders(Channel *) override;
+    void    procHeaders(std::shared_ptr<Channel>) override;
 
     void    readInfo(Stream &, ChanInfo &);
 
@@ -128,11 +128,11 @@ public:
     OGGStream()
     {}
 
-    void    readHeader(Stream &, Channel *) override;
-    int     readPacket(Stream &, Channel *) override;
-    void    readEnd(Stream &, Channel *) override;
+    void    readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int     readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void    readEnd(Stream &, std::shared_ptr<Channel>) override;
 
-    void    readHeaders(Stream &, Channel *, OggPage &);
+    void    readHeaders(Stream &, std::shared_ptr<Channel>, OggPage &);
 
     OggVorbisSubStream  vorbis;
     OggTheoraSubStream  theora;

--- a/core/common/pcp.cpp
+++ b/core/common/pcp.cpp
@@ -51,7 +51,7 @@ void PCPStream::readVersion(Stream &in)
 }
 
 // ------------------------------------------
-void PCPStream::readHeader(Stream &in, Channel *)
+void PCPStream::readHeader(Stream &in, std::shared_ptr<Channel>)
 {
 //  AtomStream atom(in);
 
@@ -85,7 +85,7 @@ void PCPStream::flush(Stream &in)
 }
 
 // ------------------------------------------
-int PCPStream::readPacket(Stream &in, Channel *)
+int PCPStream::readPacket(Stream &in, std::shared_ptr<Channel>)
 {
     BroadcastState bcs;
     return readPacket(in, bcs);
@@ -161,7 +161,7 @@ int PCPStream::readPacket(Stream &in, BroadcastState &bcs)
 }
 
 // ------------------------------------------
-void PCPStream::readEnd(Stream &, Channel *)
+void PCPStream::readEnd(Stream &, std::shared_ptr<Channel>)
 {
 }
 
@@ -200,7 +200,7 @@ void PCPStream::readPushAtoms(AtomStream &atom, int numc, BroadcastState &bcs)
 
         if (chanID.isSet())
         {
-            Channel *ch = chanMgr->findChannelByID(chanID);
+            auto ch = chanMgr->findChannelByID(chanID);
             if (ch)
                 if (ch->isBroadcasting() || (!ch->isFull() && !servMgr->relaysFull() && ch->info.id.isSame(chanID)))
                     s = servMgr->allocServent();
@@ -287,7 +287,7 @@ void PCPStream::readRootAtoms(AtomStream &atom, int numc, BroadcastState &bcs)
 }
 
 // ------------------------------------------
-void PCPStream::readPktAtoms(Channel *ch, AtomStream &atom, int numc, BroadcastState &bcs)
+void PCPStream::readPktAtoms(std::shared_ptr<Channel> ch, AtomStream &atom, int numc, BroadcastState &bcs)
 {
     ChanPacket pack;
     ID4 type;
@@ -446,8 +446,8 @@ void PCPStream::readHostAtoms(AtomStream &atom, int numc, BroadcastState &bcs)
 // ------------------------------------------
 void PCPStream::readChanAtoms(AtomStream &atom, int numc, BroadcastState &bcs)
 {
-    Channel *ch=NULL;
-    ChanHitList *chl=NULL;
+    std::shared_ptr<Channel> ch = NULL;
+    ChanHitList *chl = NULL;
     ChanInfo newInfo;
 
     ch = chanMgr->findChannelByID(bcs.chanID);

--- a/core/common/pcp.h
+++ b/core/common/pcp.h
@@ -226,9 +226,9 @@ public:
 
     bool    sendPacket(ChanPacket &, GnuID &) override;
     void    flush(Stream &) override;
-    void    readHeader(Stream &, Channel *) override;
-    int     readPacket(Stream &, Channel *) override;
-    void    readEnd(Stream &, Channel *) override;
+    void    readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int     readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void    readEnd(Stream &, std::shared_ptr<Channel>) override;
 
     int             readPacket(Stream &, BroadcastState &);
     void            flushOutput(Stream &in, BroadcastState &);
@@ -240,7 +240,7 @@ public:
     void            readHostAtoms(AtomStream &, int, BroadcastState &);
     void            readPushAtoms(AtomStream &, int, BroadcastState &);
 
-    void            readPktAtoms(Channel *, AtomStream &, int, BroadcastState &);
+    void            readPktAtoms(std::shared_ptr<Channel>, AtomStream &, int, BroadcastState &);
     void            readRootAtoms(AtomStream &, int, BroadcastState &);
 
     int             readBroadcastAtoms(AtomStream &, int, BroadcastState &);

--- a/core/common/servent.cpp
+++ b/core/common/servent.cpp
@@ -93,7 +93,7 @@ bool    Servent::isFiltered(int f)
 }
 
 // -----------------------------------
-bool Servent::canStream(Channel *ch)
+bool Servent::canStream(std::shared_ptr<Channel> ch)
 {
     if (ch==NULL)
         return false;
@@ -820,7 +820,7 @@ bool Servent::handshakeStream(ChanInfo &chanInfo)
     bool chanFound=false;
     bool chanReady=false;
 
-    Channel *ch = chanMgr->findChannelByID(chanInfo.id);
+    auto ch = chanMgr->findChannelByID(chanInfo.id);
     if (ch)
     {
         sendHeader = true;
@@ -2034,7 +2034,7 @@ void Servent::processStream(bool doneHandshake, ChanInfo &chanInfo)
 
         servMgr->totalStreams++;
 
-        Channel *ch = chanMgr->findChannelByID(chanID);
+        auto ch = chanMgr->findChannelByID(chanID);
         if (!ch)
             throw StreamException("Channel not found");
 
@@ -2092,7 +2092,7 @@ bool Servent::waitForChannelHeader(ChanInfo &info)
 {
     for (int i=0; i<30*10; i++)
     {
-        Channel *ch = chanMgr->findChannelByID(info.id);
+        auto ch = chanMgr->findChannelByID(info.id);
         if (!ch)
             return false;
 
@@ -2115,7 +2115,7 @@ void Servent::sendRawChannel(bool sendHead, bool sendData)
     {
         sock->setWriteTimeout(DIRECT_WRITE_TIMEOUT*1000);
 
-        Channel *ch = chanMgr->findChannelByID(chanID);
+        auto ch = chanMgr->findChannelByID(chanID);
         if (!ch)
             throw StreamException("Channel not found");
 
@@ -2197,7 +2197,7 @@ void Servent::sendRawMetaChannel(int interval)
 {
     try
     {
-        Channel *ch = chanMgr->findChannelByID(chanID);
+        auto ch = chanMgr->findChannelByID(chanID);
         if (!ch)
             throw StreamException("Channel not found");
 
@@ -2317,7 +2317,7 @@ void Servent::sendPeercastChannel()
     {
         setStatus(S_CONNECTED);
 
-        Channel *ch = chanMgr->findChannelByID(chanID);
+        auto ch = chanMgr->findChannelByID(chanID);
         if (!ch)
             throw StreamException("Channel not found");
 
@@ -2366,7 +2366,7 @@ void Servent::sendPeercastChannel()
 // -----------------------------------
 void Servent::sendPCPChannel()
 {
-    Channel *ch = chanMgr->findChannelByID(chanID);
+    auto ch = chanMgr->findChannelByID(chanID);
     if (!ch)
         throw StreamException("Channel not found");
 
@@ -2401,7 +2401,7 @@ void Servent::sendPCPChannel()
 
         while (thread.active())
         {
-            Channel *ch = chanMgr->findChannelByID(chanID);
+            auto ch = chanMgr->findChannelByID(chanID);
 
             if (!ch)
             {

--- a/core/common/servent.h
+++ b/core/common/servent.h
@@ -205,10 +205,9 @@ public:
     void    sendRawChannel(bool, bool);
     void    sendRawMetaChannel(int);
     void    sendPCPChannel();
-    void    checkPCPComms(Channel *, AtomStream &);
 
     static void readICYHeader(HTTP &, ChanInfo &, char *, size_t);
-    bool    canStream(Channel *);
+    bool    canStream(std::shared_ptr<Channel>);
 
     bool    isConnected() { return status == S_CONNECTED; }
     bool    isListening() { return status == S_LISTENING; }

--- a/core/common/servhs.cpp
+++ b/core/common/servhs.cpp
@@ -341,7 +341,7 @@ void Servent::handshakeGET(HTTP &http)
             for (int i=0; i<slen; i++)
                 if (fn[i]=='&') fn[i] = 0;
 
-            Channel *c=chanMgr->channel;
+            auto c = chanMgr->channel;
             while (c)
             {
                 if ((c->status == Channel::S_BROADCASTING) &&
@@ -367,7 +367,7 @@ void Servent::handshakeGET(HTTP &http)
                         c->updateInfo(newInfo);
                     }
                 }
-                c=c->next;
+                c = c->next;
             }
         }
     }else if (strncmp(fn, "/pls/", 5) == 0)
@@ -569,7 +569,7 @@ void Servent::handshakeGIV(const char *requestLine)
     if (id.isSet())
     {
         // at the moment we don`t really care where the GIV came from, so just give to chan. no. if its waiting.
-        Channel *ch = chanMgr->findChannelByID(id);
+        auto ch = chanMgr->findChannelByID(id);
 
         if (!ch)
             throw HTTPException(HTTP_SC_NOTFOUND, 404);
@@ -1302,7 +1302,7 @@ void Servent::CMD_fetch(char *cmd, HTTP& http, HTML& html, String& jumpStr)
     info.id = chanMgr->broadcastID;
     info.id.encode(NULL, info.name, info.genre, info.bitrate);
 
-    Channel *c = chanMgr->createChannel(info, NULL);
+    auto c = chanMgr->createChannel(info, NULL);
     if (c)
         c->startURL(curl.cstr());
 
@@ -1373,7 +1373,7 @@ void Servent::CMD_stop(char *cmd, HTTP& http, HTML& html, String& jumpStr)
             id.fromStr(arg);
     }
 
-    Channel *c = chanMgr->findChannelByID(id);
+    auto c = chanMgr->findChannelByID(id);
     if (c)
         c->thread.shutdown();
 
@@ -1394,7 +1394,7 @@ void Servent::CMD_bump(char *cmd, HTTP& http, HTML& html, String& jumpStr)
     Host designation;
     designation.fromStrIP(ip.c_str(), 7144);
 
-    Channel *c = chanMgr->findChannelByID(id);
+    auto c = chanMgr->findChannelByID(id);
     if (c)
     {
         if (!ip.empty())
@@ -1447,7 +1447,7 @@ void Servent::CMD_keep(char *cmd, HTTP& http, HTML& html, String& jumpStr)
             id.fromStr(arg);
     }
 
-    Channel *c = chanMgr->findChannelByID(id);
+    auto c = chanMgr->findChannelByID(id);
     if (c)
         c->stayConnected = !c->stayConnected;
 
@@ -1634,7 +1634,7 @@ void Servent::handshakeCMD(char *cmd)
 }
 
 // -----------------------------------
-static XML::Node *createChannelXML(Channel *c)
+static XML::Node *createChannelXML(std::shared_ptr<Channel> c)
 {
     XML::Node *n = c->info.createChannelXML();
     n->add(c->createRelayXML(true));
@@ -1673,12 +1673,12 @@ void Servent::handshakeXML()
     XML::Node *an = new XML::Node("channels_relayed total=\"%d\"", chanMgr->numChannels());
     rn->add(an);
 
-    Channel *c = chanMgr->channel;
+    auto c = chanMgr->channel;
     while (c)
     {
         if (c->isActive())
             an->add(createChannelXML(c));
-        c=c->next;
+        c = c->next;
     }
 
     // add public channels
@@ -1887,7 +1887,7 @@ void Servent::handshakeWMHTTPPush(HTTP& http, const std::string& path)
     info.id = chanMgr->broadcastID;
     info.id.encode(NULL, info.name.cstr(), info.genre.cstr(), info.bitrate);
 
-    Channel *c = chanMgr->findChannelByID(info.id);
+    auto c = chanMgr->findChannelByID(info.id);
     if (c)
     {
         LOG_CHANNEL("WMHTTP Push channel already active, closing old one");
@@ -1950,7 +1950,7 @@ void Servent::handshakeHTTPPush(const std::string& args)
 
     ChanInfo info = createChannelInfo(chanMgr->broadcastID, chanMgr->broadcastMsg, query, http.headers.get("Content-Type"));
 
-    Channel *c = chanMgr->findChannelByID(info.id);
+    auto c = chanMgr->findChannelByID(info.id);
     if (c)
     {
         LOG_CHANNEL("HTTP Push channel already active, closing old one");
@@ -2006,7 +2006,7 @@ void Servent::handshakeICY(Channel::SRC_TYPE type, bool isHTTP)
     else
         sock->writeLine("OK");
 
-    Channel *c = chanMgr->findChannelByID(info.id);
+    auto c = chanMgr->findChannelByID(info.id);
     if (c)
     {
         LOG_CHANNEL("ICY channel already active, closing old one");

--- a/core/common/servmgr.cpp
+++ b/core/common/servmgr.cpp
@@ -1020,7 +1020,7 @@ void ServMgr::saveSettings(const char *fn)
             }
         }
 
-        Channel *c = chanMgr->channel;
+        std::shared_ptr<Channel> c = chanMgr->channel;
         while (c)
         {
             char idstr[64];
@@ -1396,7 +1396,7 @@ void ServMgr::loadSettings(const char *fn)
                 }else
                 {
                     info.bcID = chanMgr->broadcastID;
-                    Channel *c = chanMgr->createChannel(info, NULL);
+                    auto c = chanMgr->createChannel(info, NULL);
                     if (c)
                         c->startURL(sourceURL.cstr());
                 }
@@ -1483,9 +1483,7 @@ bool ServMgr::getChannel(char *str, ChanInfo &info, bool relay)
 {
     procConnectArgs(str, info);
 
-    Channel *ch;
-
-    ch = chanMgr->findChannelByNameID(info);
+    auto ch = chanMgr->findChannelByNameID(info);
     if (ch)
     {
         if (!ch->isPlaying())

--- a/core/common/template.cpp
+++ b/core/common/template.cpp
@@ -143,7 +143,7 @@ bool Template::writeLoopVariable(Stream &s, const String &varName, int loop)
 {
     if (varName.startsWith("loop.channel."))
     {
-        Channel *ch = chanMgr->findChannelByIndex(loop);
+        auto ch = chanMgr->findChannelByIndex(loop);
         if (ch)
             return ch->writeVariable(s, varName+13);
     }else if (varName.startsWith("loop.servent."))
@@ -223,7 +223,7 @@ bool Template::writePageVariable(Stream &s, const String &varName, int loop)
         {
             GnuID id;
             id.fromStr(idstr);
-            Channel *ch = chanMgr->findChannelByID(id);
+            auto ch = chanMgr->findChannelByID(id);
             if (varName == "page.channel.exist")
             {
                 if (ch)

--- a/core/common/threading.h
+++ b/core/common/threading.h
@@ -132,6 +132,7 @@ class ThreadInfo
 public:
     ThreadInfo()
         : m_active(false)
+        , channel(NULL)
     {
         func         = NULL;
         data         = NULL;
@@ -144,6 +145,7 @@ public:
     std::atomic<bool>   m_active;
     THREAD_FUNC     func;
     void            *data;
+    std::shared_ptr<class Channel> channel;
 
     THREAD_HANDLE   handle;
 };

--- a/core/common/url.cpp
+++ b/core/common/url.cpp
@@ -29,7 +29,7 @@
 #endif
 
 // ------------------------------------------------
-void URLSource::stream(Channel *ch)
+void URLSource::stream(std::shared_ptr<Channel> ch)
 {
     String url;
     while (ch->thread.active() && !peercastInst->isQuitting)
@@ -94,7 +94,7 @@ ChanInfo::PROTOCOL URLSource::getSourceProtocol(char*& fileName)
 }
 
 // ------------------------------------------------
-::String URLSource::streamURL(Channel *ch, const char *url)
+::String URLSource::streamURL(std::shared_ptr<Channel> ch, const char *url)
 {
     String nextURL;
 

--- a/core/common/url.h
+++ b/core/common/url.h
@@ -31,8 +31,8 @@ public:
         baseurl.set(url);
     }
 
-    ::String        streamURL(Channel *, const char *);
-    void            stream(Channel *) override;
+    ::String        streamURL(std::shared_ptr<Channel>, const char *);
+    void            stream(std::shared_ptr<Channel>) override;
     int             getSourceRate() override;
     int             getSourceRateAvg() override;
 

--- a/core/common/wmhttp.cpp
+++ b/core/common/wmhttp.cpp
@@ -2,17 +2,17 @@
 
 extern ASFInfo parseASFHeader(Stream &in); // from mms.cpp
 
-void WMHTTPStream::readEnd(Stream &, Channel *)
+void WMHTTPStream::readEnd(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-void WMHTTPStream::readHeader(Stream &, Channel *)
+void WMHTTPStream::readHeader(Stream &, std::shared_ptr<Channel>)
 {
 }
 
 // ------------------------------------------
-int WMHTTPStream::readPacket(Stream &in, Channel *ch)
+int WMHTTPStream::readPacket(Stream &in, std::shared_ptr<Channel> ch)
 {
     WMHTTPChunk c;
 

--- a/core/common/wmhttp.h
+++ b/core/common/wmhttp.h
@@ -51,9 +51,9 @@ public:
         : m_seqno(0)
     {}
 
-    void    readHeader(Stream &, Channel *) override;
-    int     readPacket(Stream &, Channel *) override;
-    void    readEnd(Stream &, Channel *) override;
+    void    readHeader(Stream &, std::shared_ptr<Channel>) override;
+    int     readPacket(Stream &, std::shared_ptr<Channel>) override;
+    void    readEnd(Stream &, std::shared_ptr<Channel>) override;
 
     uint32_t m_seqno;
 };

--- a/tests/chanmgr_unittest.cpp
+++ b/tests/chanmgr_unittest.cpp
@@ -31,7 +31,7 @@ TEST_F(ChanMgrFixture, initialState)
 
     id.clear();
 
-    ASSERT_EQ(NULL, x->channel);
+    ASSERT_EQ(nullptr, x->channel);
     ASSERT_EQ(NULL, x->hitlist);
     ASSERT_EQ(PCP_BROADCAST_FLAGS, x->broadcastID.getFlags());
 
@@ -67,11 +67,10 @@ TEST_F(ChanMgrFixture, initialState)
 TEST_F(ChanMgrFixture, createChannel)
 {
     ChanInfo info;
-    Channel *c;
 
-    ASSERT_EQ(NULL, x->channel);
+    ASSERT_EQ(nullptr, x->channel);
 
-    c = x->createChannel(info, NULL);
+    auto c = x->createChannel(info, NULL);
 
     ASSERT_TRUE(c);
     ASSERT_EQ(c, x->channel);

--- a/tests/chanmgr_unittest.cpp
+++ b/tests/chanmgr_unittest.cpp
@@ -72,7 +72,7 @@ TEST_F(ChanMgrFixture, createChannel)
 
     auto c = x->createChannel(info, NULL);
 
-    ASSERT_TRUE(c);
+    ASSERT_TRUE(c != nullptr); // ASSERT_TRUE(c) と書くとエラーになるコンパイラがある。
     ASSERT_EQ(c, x->channel);
 
     x->deleteChannel(c);

--- a/tests/hostgraph_unittest.cpp
+++ b/tests/hostgraph_unittest.cpp
@@ -15,9 +15,9 @@ TEST_F(HostGraphFixture, constructorNullChannel)
 
 TEST_F(HostGraphFixture, simplestCase)
 {
-    auto ch = new Channel();
+    auto ch = std::make_shared<Channel>();
     auto hitList = new ChanHitList();
-    Defer reclaim([=]() { delete ch; delete hitList; });
+    Defer reclaim([=]() { delete hitList; });
 
     JrpcApi::HostGraph graph(ch, hitList);
 
@@ -26,9 +26,9 @@ TEST_F(HostGraphFixture, simplestCase)
 
 TEST_F(HostGraphFixture, withHitList)
 {
-    auto ch = new Channel();
+    auto ch = std::make_shared<Channel>();
     auto hitList = new ChanHitList();
-    Defer reclaim([=]() { delete ch; delete hitList; });
+    Defer reclaim([=]() { delete hitList; });
     ChanHit hit;
 
     hit.init();


### PR DESCRIPTION
Servent スレッドが削除された Channel オブジェクトを操作する可能性が無くなったはず。
また、メモリアライメントにかかわらず、ChanMgr::deleteChannel がアトミックに動作するか。