### PR TITLE
Channel feeds concurrency and manual updates

### DIFF
--- a/core/common/chandir.cpp
+++ b/core/common/chandir.cpp
@@ -171,7 +171,7 @@ bool ChannelDirectory::update(UpdateMode mode)
 
     double t0 = sys->getDTime();
     std::vector<std::thread> workers;
-    std::mutex mutex;;
+    std::mutex mutex; // m_channels を保護するミューテックス。
     m_channels.clear();
     for (auto& feed : m_feeds)
     {

--- a/core/common/chandir.cpp
+++ b/core/common/chandir.cpp
@@ -208,7 +208,7 @@ bool ChannelDirectory::update(UpdateMode mode)
              return a.numDirects > b.numDirects;
          });
     m_lastUpdate = sys->getTime();
-    LOG_INFO("Channel feed update total: %zu channels in %f sec",
+    LOG_INFO("Channel feed update: total of %zu channels in %f sec",
              m_channels.size(),
              sys->getDTime() - t0);
     return true;

--- a/core/common/chandir.cpp
+++ b/core/common/chandir.cpp
@@ -111,14 +111,14 @@ static bool getFeed(std::string url, std::vector<ChannelEntry>& out)
     WriteBufferedStream brsock(&*rsock);
 
     try {
-        LOG_DEBUG("Connecting to %s ...", feed.host().c_str());
+        LOG_TRACE("Connecting to %s ...", feed.host().c_str());
         rsock->open(host);
         rsock->connect();
 
         HTTP rhttp(brsock);
 
         auto request_line = "GET " + feed.path() + "?host=" + cgi::escape(servMgr->serverHost) + " HTTP/1.0";
-        LOG_DEBUG("Request line: %s", request_line.c_str());
+        LOG_TRACE("Request line to %s: %s", feed.host().c_str(), request_line.c_str());
 
         rhttp.writeLineF("%s", request_line.c_str());
         rhttp.writeLineF("%s %s", HTTP_HS_HOST, feed.host().c_str());
@@ -128,7 +128,7 @@ static bool getFeed(std::string url, std::vector<ChannelEntry>& out)
 
         auto code = rhttp.readResponse();
         if (code != 200) {
-            LOG_DEBUG("%s: status code %d", feed.host().c_str(), code);
+            LOG_ERROR("%s: status code %d", feed.host().c_str(), code);
             return false;
         }
 

--- a/core/common/chandir.h
+++ b/core/common/chandir.h
@@ -105,8 +105,8 @@ class ChannelDirectory : public VariableWriter
 {
 public:
     enum UpdateMode {
-        kUpdateSlow,
-        kUpdateQuick,
+        kUpdateAuto,
+        kUpdateManual,
     };
 
     ChannelDirectory();
@@ -121,7 +121,7 @@ public:
     int totalListeners();
     int totalRelays();
 
-    bool update(UpdateMode mode = kUpdateSlow);
+    bool update(UpdateMode mode = kUpdateAuto);
 
     bool writeChannelVariable(Stream& out, const String& varName, int index);
     bool writeFeedVariable(Stream& out, const String& varName, int index);

--- a/core/common/chandir.h
+++ b/core/common/chandir.h
@@ -104,6 +104,11 @@ public:
 class ChannelDirectory : public VariableWriter
 {
 public:
+    enum UpdateMode {
+        kUpdateSlow,
+        kUpdateQuick,
+    };
+
     ChannelDirectory();
 
     int numChannels();
@@ -116,7 +121,7 @@ public:
     int totalListeners();
     int totalRelays();
 
-    bool update();
+    bool update(UpdateMode mode = kUpdateSlow);
 
     bool writeChannelVariable(Stream& out, const String& varName, int index);
     bool writeFeedVariable(Stream& out, const String& varName, int index);

--- a/core/common/servent.h
+++ b/core/common/servent.h
@@ -289,6 +289,7 @@ private:
     void CMD_control_rtmp(char *cmd, HTTP& http, HTML& html, String& jumpStr);
     void CMD_edit_bcid(char *cmd, HTTP& http, HTML& html, String& jumpStr);
     void CMD_fetch(char *cmd, HTTP& http, HTML& html, String& jumpStr);
+    void CMD_fetch_feeds(char *cmd, HTTP& http, HTML& html, String& jumpStr);
     void CMD_keep(char *cmd, HTTP& http, HTML& html, String& jumpStr);
     void CMD_login(char *cmd, HTTP& http, HTML& html, String& jumpStr);
     void CMD_logout(char *cmd, HTTP& http, HTML& html, String& jumpStr);

--- a/core/common/servhs.cpp
+++ b/core/common/servhs.cpp
@@ -1304,7 +1304,7 @@ void Servent::CMD_fetch(char *cmd, HTTP& http, HTML& html, String& jumpStr)
 
 void Servent::CMD_fetch_feeds(char *cmd, HTTP& http, HTML& html, String& jumpStr)
 {
-    servMgr->channelDirectory.update(ChannelDirectory::kUpdateQuick);
+    servMgr->channelDirectory.update(ChannelDirectory::kUpdateManual);
 
     if (!http.headers.get("Referer").empty())
         jumpStr.sprintf("%s", http.headers.get("Referer").c_str());

--- a/core/common/servhs.cpp
+++ b/core/common/servhs.cpp
@@ -1302,6 +1302,16 @@ void Servent::CMD_fetch(char *cmd, HTTP& http, HTML& html, String& jumpStr)
     jumpStr.sprintf("/%s/channels.html", servMgr->htmlPath);
 }
 
+void Servent::CMD_fetch_feeds(char *cmd, HTTP& http, HTML& html, String& jumpStr)
+{
+    servMgr->channelDirectory.update(ChannelDirectory::kUpdateQuick);
+
+    if (!http.headers.get("Referer").empty())
+        jumpStr.sprintf("%s", http.headers.get("Referer").c_str());
+    else
+        jumpStr.sprintf("/%s/channels.html", servMgr->htmlPath);
+}
+
 // サーバントを停止する機能を追加したい時に役に立つかも。
 #if 0
 void Servent::CMD_stopserv(char *cmd, HTTP& http, HTML& html, String& jumpStr)
@@ -1581,6 +1591,9 @@ void Servent::handshakeCMD(char *query)
         }else if (cmd == "fetch")
         {
             CMD_fetch(query, http, html, jumpStr);
+        }else if (cmd == "fetch_feeds")
+        {
+            CMD_fetch_feeds(query, http, html, jumpStr);
         }else if (cmd == "keep")
         {
             CMD_keep(query, http, html, jumpStr);

--- a/ui/catalogs/ja.json
+++ b/ui/catalogs/ja.json
@@ -75,6 +75,7 @@
     "Bump"                    : "バンプ",
     "Stop"                    : "停止",
     "Edit"                    : "編集",
+    "Auto-updates every 5 minutes. Manual updates have a cooldown of 30 seconds." : "5分間隔で自動更新。手動更新は30秒のクールダウンが必要です。",
 
     // relayinfo.html
     "Channel Information"     : "チャンネル情報",

--- a/ui/html-master/channels.html
+++ b/ui/html-master/channels.html
@@ -96,6 +96,7 @@
         {$servMgr.numExternalChannels} channels,
         {$servMgr.channelDirectory.totalListeners} listeners,
         {$servMgr.channelDirectory.totalRelays} relays. ({$servMgr.channelDirectory.lastUpdate})
+        <a href="/admin?cmd=fetch_feeds" title="{#Auto-updates every 5 minutes. Manual updates have a cooldown of 30 seconds.}">{#Update}</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
チャンネルリストを手動で更新することができるようにした。また、この際複数のソースからの index.txt の取得を同時に行って処理を速めるようにした。