### PR TITLE
viewxml admin コマンドのHTTP応答に LF 改行が使われていることの修正

### DIFF
--- a/core/common/html.cpp
+++ b/core/common/html.cpp
@@ -33,7 +33,6 @@
 HTML::HTML(const char *t, Stream &o)
 {
     out = &o;
-    out->writeCRLF = false;
 
     title.set(t);
     tagLevel = 0;

--- a/core/common/html.cpp
+++ b/core/common/html.cpp
@@ -28,6 +28,7 @@
 #include "version2.h"
 #include "template.h"
 #include "sstream.h"
+#include "defer.h"
 
 // --------------------------------------
 HTML::HTML(const char *t, Stream &o)
@@ -43,6 +44,7 @@ HTML::HTML(const char *t, Stream &o)
 void HTML::writeOK(const char *content, const std::map<std::string,std::string>& additionalHeaders)
 {
     bool crlf = out->writeCRLF;
+    Defer cb([=] { out->writeCRLF = crlf; });
 
     out->writeCRLF = true;
     out->writeLine(HTTP_SC_OK);
@@ -56,7 +58,6 @@ void HTML::writeOK(const char *content, const std::map<std::string,std::string>&
         out->writeLineF("%s: %s", pair.first.c_str(), pair.second.c_str());
 
     out->writeLine("");
-    out->writeCRLF = crlf;
 }
 
 // --------------------------------------
@@ -128,11 +129,11 @@ void HTML::writeRawFile(const char *fileName, const char *mimeType)
 void HTML::locateTo(const char *url)
 {
     bool prev = out->writeCRLF;
+    Defer cb([=] { out->writeCRLF = prev; });
     out->writeCRLF = true;
     out->writeLine(HTTP_SC_FOUND);
     out->writeLineF("Location: %s", url);
     out->writeLine("");
-    out->writeCRLF = prev;
 }
 
 // --------------------------------------

--- a/core/common/xml.cpp
+++ b/core/common/xml.cpp
@@ -355,7 +355,7 @@ void XML::write(Stream &out)
     if (!root)
         throw StreamException("No XML root");
 
-    out.writeLine("<?xml version=\"1.0\" encoding=\"utf-8\" ?>");
+    out.writeString("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n");
     root->write(out, 1);
 }
 
@@ -365,7 +365,7 @@ void XML::writeCompact(Stream &out)
     if (!root)
         throw StreamException("No XML root");
 
-    out.writeLine("<?xml ?>");
+    out.writeString("<?xml ?>\n");
     root->write(out, 1);
 }
 

--- a/tests/servent_unittest.cpp
+++ b/tests/servent_unittest.cpp
@@ -458,3 +458,19 @@ TEST_F(ServentFixture, writeVariable)
     ASSERT_TRUE(s.writeVariable(mem, "gnet.routeTime"));
     ASSERT_STREQ("-", mem.str().c_str());
 }
+
+TEST_F(ServentFixture, handshakeIncoming_viewxml)
+{
+    MockClientSocket* mock;
+
+    s.sock = mock = new MockClientSocket();
+    s.sock->host = Host("127.0.0.1", 12345);
+    mock->incoming.str("GET /admin?cmd=viewxml HTTP/1.0\r\n"
+                       "\r\n");
+
+    ASSERT_NO_THROW(s.handshakeIncoming());
+
+    ASSERT_TRUE(str::has_prefix(mock->outgoing.str(), "HTTP/1.0 200 OK\r\n"));
+
+    delete mock;
+}


### PR DESCRIPTION
応答行とヘッダー行が CRLF ではなく LF で終端されていた。