### PR TITLE
MediaFoundationとUWPのMediaElementでのWMV配信の再生が出来ないバグを修正

### DIFF
--- a/core/common/servent.cpp
+++ b/core/common/servent.cpp
@@ -770,9 +770,8 @@ void Servent::handshakeStream_readHeaders(bool& gotPCP, unsigned int& reqPos, in
         else if (http.isHeader("Pragma"))
         {
             char *ssc = stristr(arg, "stream-switch-count=");
-            char *so = stristr(arg, "stream-offset");
 
-            if (ssc || so)
+            if (ssc)
             {
                 nsSwitchNum = 1;
                 //nsSwitchNum = atoi(ssc+20);

--- a/ui/html-master/settings.html
+++ b/ui/html-master/settings.html
@@ -290,6 +290,8 @@
             <td>
               <select name="wmvProtocol">
                 <option {@if servMgr.wmvProtocol == "http"}selected{@end}>http</option>
+                <option {@if servMgr.wmvProtocol == "httpt"}selected{@end}>httpt</option>
+                <option {@if servMgr.wmvProtocol == "httpu"}selected{@end}>httpu</option>
                 <option {@if servMgr.wmvProtocol == "mms"}selected{@end}>mms</option>
                 <option {@if servMgr.wmvProtocol == "mmsh"}selected{@end}>mmsh</option>
               </select>


### PR DESCRIPTION
MediaFoundationとUWPのMediaElementで
mmsプロトコルを使った再生ができないので原因を調べて修正しました
あと試す時は再生する時にhttp://をmms://に変えて再生して下さい

mms://のURLを再生できるMediaFoundationのプレイヤーのサンプル。ビルドして使えます
https://github.com/Microsoft/Windows-classic-samples/tree/master/Samples/Win7Samples/multimedia/mediafoundation/protectedplayback

protectedplaybackのビルドで足りないソースはここから入手できます
https://github.com/Microsoft/Windows-classic-samples/tree/master/Samples/Win7Samples/multimedia/mediafoundation/common

もっと簡単に試したい場合は
WMPでもMediaFoundationを使ったWMV配信の再生が出来るみたいです
その方法は配信URLをhttpt://かhttpu://に変えてWMPで開けばMediaFoundationで再生できます
この方法を使えばWMV(H264+AAC)配信もコーデック無しでWMPだけで再生できますね