### PR TITLE
設定ファイルの更新時に所有者とモードを引き継ぐようにした。

### DIFF
--- a/core/common/sys.h
+++ b/core/common/sys.h
@@ -136,6 +136,11 @@ public:
 
     virtual void rename(const std::string& oldpath, const std::string& newpath) = 0;
 
+    virtual void copyOwnershipPermission(const std::string& from, const std::string& to)
+    {
+        throw NotImplementedException(__func__);
+    }
+
     unsigned int idleSleepTime;
 
     class LogBuffer *logBuf;

--- a/core/unix/usys.cpp
+++ b/core/unix/usys.cpp
@@ -430,3 +430,26 @@ void USys::rename(const std::string& oldpath, const std::string& newpath)
         throw GeneralException( str::format("rename: %s", str::strerror(errno).c_str()).c_str() );
     }
 }
+
+// ---------------------------------
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+void USys::copyOwnershipPermission(const std::string& from, const std::string& to)
+{
+    struct stat statbuf = {};
+    if (::stat(from.c_str(), &statbuf) == -1) {
+        auto msg = str::STR("copyOwnershipPermission: Failed to get file status: ", from);
+        throw GeneralException(msg.c_str());
+    }
+
+    if (::chmod(to.c_str(), statbuf.st_mode) == -1) {
+        auto msg = str::STR("copyOwnershipPermission: Failed to set file mode: ", to);
+        throw GeneralException(msg.c_str());
+    }
+
+    if (::chown(to.c_str(), statbuf.st_uid, statbuf.st_gid) == -1) {
+        auto msg = str::STR("copyOwnershipPermission: Failed to set file owner/group: ", to);
+        throw GeneralException(msg.c_str());
+    }
+}

--- a/core/unix/usys.h
+++ b/core/unix/usys.h
@@ -54,6 +54,8 @@ public:
 
     void rename(const std::string& oldpath, const std::string& newpath) override;
 
+    void copyOwnershipPermission(const std::string& from, const std::string& to) override;
+
     peercast::Random rndGen;
 private:
 


### PR DESCRIPTION
また設定ファイルの新規作成時にグループとグループ外の読み書きを禁止した。(umask 066)

パスワードの書かれたファイルが他のユーザーから見えるのはよくなかった。Windowsでも何かできるのかもしれないけどわからない。

#110 への対応。