### PR TITLE
include漏れのためにMSYS2環境においてビルドできなくなっていたのを修正

### DIFF
--- a/core/common/threading.h
+++ b/core/common/threading.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include <memory>
 
 // ------------------------------------
 class ThreadInfo;


### PR DESCRIPTION
`#include <memory>`がないことで`std::shared_ptr`が存在しない扱いになっており、少なくとも私の環境においてはそれが原因でビルドが必ず失敗する状況でした
`#include <memory>`を追記したことでビルドできるようになったのでマージお願いします