### PR TITLE
AMF0の数値(double)の文字列化の精度をちゃんとした。

### DIFF
--- a/core/common/amf0.h
+++ b/core/common/amf0.h
@@ -253,53 +253,7 @@ namespace amf0
             }
         }
 
-        std::string inspect() const
-        {
-            switch (m_type)
-            {
-            case kNumber:
-                return str::format("%g", m_number);
-            case kObject:
-            case kArray:
-            {
-                std::string buf = "{";
-                bool first = true;
-                for (auto pair : m_object)
-                {
-                    if (!first)
-                        buf += ",";
-                    first = false;
-                    buf += string(pair.first).inspect() + ":" + pair.second.inspect();
-                }
-                buf += "}";
-                return buf;
-            }
-            case kString:
-                return str::json_inspect(m_string);
-            case kNull:
-                return "null";
-            case kBool:
-                return (m_bool) ? "true" : "false";
-            case kDate:
-                return "(" + std::to_string(m_date.unixTime) + ", " + std::to_string(m_date.timezone) + ")";
-            case kStrictArray:
-            {
-                std::string buf = "[";
-                bool first = true;
-                for (auto elt : m_strict_array)
-                {
-                    if (!first)
-                        buf += ",";
-                    first = false;
-                    buf += elt.inspect();
-                }
-                buf += "]";
-                return buf;
-            }
-            default:
-                throw std::runtime_error(str::format("inspect: unknown type %d", m_type));
-            }
-        }
+        std::string inspect() const;
 
         double number() const
         {

--- a/tests/amf0_unittest.cpp
+++ b/tests/amf0_unittest.cpp
@@ -3,6 +3,9 @@
 
 #include <gtest/gtest.h>
 
+#include <limits> // numeric_limits
+#include <string> // stod
+
 using namespace amf0;
 
 class amf0Fixture : public ::testing::Test {
@@ -335,4 +338,29 @@ TEST_F(amf0Fixture, Null_at_size_count)
     ASSERT_THROW(v.at("a"), std::runtime_error);
     ASSERT_THROW(v.count("a"), std::runtime_error);
     ASSERT_THROW(v.size(), std::runtime_error);
+}
+
+TEST_F(amf0Fixture, Number_inspect)
+{
+    ASSERT_EQ(amf0::Value::number(0.0).inspect(), "0");
+    ASSERT_EQ(amf0::Value::number(-0.0).inspect(), "-0");
+    ASSERT_EQ(amf0::Value::number(1705328958.0).inspect(), "1705328958");
+}
+
+// double-string-double
+TEST_F(amf0Fixture, Number_precision)
+{
+    std::vector<double> vs = {
+        0.0,
+        -0.0,
+        1.0,
+        1.0/7.0,
+        std::numeric_limits<double>::max(),
+        std::numeric_limits<double>::min(),
+        std::numeric_limits<double>::lowest(),
+    };
+    for (int i = 0; i < vs.size(); i++) {
+        double v = vs[i];
+        ASSERT_EQ(std::stod(amf0::Value::number(v).inspect()), v);
+    }
 }

--- a/ui/html-master/login.html
+++ b/ui/html-master/login.html
@@ -15,22 +15,22 @@
                 justify-content:center;
                 align-items:center;
                 z-index: 0">
-    <table class="table-panel" style="">
-      <tr align=middle>
-        <td colspan="2"><strong>PeerCast</strong></td>
-      </tr>
-      <tr>
-        <td>{#_Password_login}</TD>
-        <td><input type=password size=10 name=pass style="width: 200px"> </td>
-      </tr>
-      <tr>
-        <tD colspan="2">
-          <div align="center">
-            <input id=submit type=submit value="{#Login}" name=submit>
-          </div>
-        </td>
-      </tr>
-    </table>
-</div>
+      <table class="table-panel" style="">
+        <tr align=middle>
+          <td colspan="2"><strong>PeerCast</strong></td>
+        </tr>
+        <tr>
+          <td>{#_Password_login}</TD>
+          <td><input type=password size=10 name=pass style="width: 200px"></td>
+        </tr>
+        <tr>
+          <td colspan="2">
+            <div align="center">
+              <input id=submit type=submit value="{#Login}" name=submit>
+            </div>
+          </td>
+        </tr>
+      </table>
+    </div>
   </form>
 </div>


### PR DESCRIPTION
当初 %f 相当の文字列化をしていたが、整数に小数点が付くのがいやで、%g
にしたところ Unix epoch からの経過秒数が指数表記になって精度を失なった
ため、ちゃんとした。