### PR TITLE
一部のコンパイラでビルドができない問題を修正

### DIFF
--- a/core/common/bbs.h
+++ b/core/common/bbs.h
@@ -2,6 +2,7 @@
 #define BBS_H
 
 #include <memory>
+#include <string>
 
 namespace bbs {
     using namespace std;


### PR DESCRIPTION
コンパイラによっては`#include <string>`の明示が必要なようです。
よろしくお願いいたします。